### PR TITLE
feat(validator): support multi-claim analysis and input length limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,29 +1,27 @@
-
 # Configuración de la base de datos.
 DB_TYPE=mysql # mysql | postgres | sqlite | mariadb | oracle | mssql
 DB_HOST=127.0.0.1
-DB_PORT=3306 # Opcional. Por defecto 3306
+DB_PORT=3306
 DB_USER=root
 DB_PASSWORD=
 DB_NAME=veriqo
 
 # Claves de API para servicios externos.
-OPENAI_API_KEY=
-NEWS_API_KEY=
-CLAUDE_API_KEY=
-BRAVE_API_KEY=
-GOOGLE_CLOUD_API_KEY=
-GOOGLE_CX_ID=
+OPENAI_API_KEY= # Clave para la API de OpenAI.
+CLAUDE_API_KEY= # Clave para la API de Claude.
+BRAVE_API_KEY= # Clave para la API de Brave Search.
+GOOGLE_CLOUD_API_KEY= # Clave para la API de Google Cloud.
+GOOGLE_CX_ID= # ID del motor de búsqueda personalizado de Google.
+NEWS_API_KEY= # Clave para la API de noticias.
 
 # Configuración del servidor.
-PORT=3001 # Puerto donde se expone la API
+PORT=3001
 
 # Modelos LLM y embeddings.
 VALIDATOR_MODEL=claude-3-5-sonnet-20241022
+VALIDATOR_MAX_INPUT_CHARS=3000 # Máximo de caracteres que admite el agente validador.
 FACTCHECKER_MODEL=gpt-4o
+FACT_CHECK_CACHE_DAYS=7 # Días válidos para reutilizar una verificación de hechos almacenada en caché.
 EMBEDDING_MODEL=text-embedding-3-small
 EMBEDDING_MODEL_PROVIDER=openai # openai | claude
-EMBEDDING_SIMILARITY_THRESHOLD=0.80 # Valor decimal entre 0.00 y 1.00
-
-# Parámetros adicionales.
-FACT_CHECK_CACHE_DAYS=7 # Días válidos para reutilizar una verificación
+EMBEDDING_SIMILARITY_THRESHOLD=0.80 # Valor decimal entre 0.00 y 1.00. Umbral mínimo de similitud para considerar dos embeddings relacionados.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,53 @@
+# 📄 Changelog
+
+> ℹ️ This changelog is written in English to comply with international development standards and ensure compatibility with CI/CD tools.
+> All user-facing documentation and API responses (e.g., Swagger) are available in Spanish.
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- Support for analyzing multiple claims in a single prompt (`ValidatorAgent`)
+- Input length limit defined by `VALIDATOR_MAX_INPUT_CHARS` (recommended: 3000)
+- Validation now emits separate events for each claim needing factual verification
+- New documentation examples in `README.md` to demonstrate multi-claim usage
+- Initial `CHANGELOG.md` based on Keep a Changelog format
+
+## [1.0.0] – 2025‑04‑19
+
+### Added
+
+- `ValidatorAgent` for analyzing and evaluating factual claims
+- `FactCheckerAgent` for verifying facts using real sources (Brave, Google, NewsAPI)
+- Semantic normalization using OpenAI embeddings
+- Full traceability in the database with TypeORM
+- REST endpoints documented with Swagger UI (`/api-docs`)
+- Modular documentation split into separate files (in Spanish)
+- `mkdocs.yml` configuration with structured navigation and Material theme
+- Interactive documentation integration (Swagger + Postman collection)
+- Endpoint `POST /facts/claim` for retrieving previously verified facts
+- Endpoint `GET /facts/verifications/last` for latest factual verification with full traceability
+- DTO `AgentFactDto` with strict exposure control (`@Exclude/@Expose`)
+- Canonical claim normalization using internal `normalizeClaim()` helper
+- `sourcesRetrieved` and `sourcesUsed` saved in `AgentVerification`
+- Automatic inclusion of `reasoning`, `sources_used` and `sources_retrieved` in public API
+
+### Removed
+
+- Redundant `sources` property from `AgentFact` and `AgentVerification`
+- `@ManyToOne` relationship to `AgentSource` (replaced by explicit `verificationId`)
+
+### Fixed
+
+- Removed `embedding` field from all public API responses
+- Fixed `class-validator` rejections on hidden properties
+- Fixed MySQL syntax error on `array` by using `simple-array` instead
+- Removed duplicated `findByNormalizedClaim()` in `AgentFactService`
+
+[Unreleased]: https://github.com/davidlosasgonzalez/veriqo-server/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/davidlosasgonzalez/veriqo-server/releases/tag/v1.0.0

--- a/README.md
+++ b/README.md
@@ -49,14 +49,22 @@ curl -X POST http://localhost:3001/api/validators/analyze \
   -d '{"prompt":"El sol es una estrella.","waitForFact":true}'
 ```
 
-### Obtener la última verificación factual
+> ℹ️ Nota importante: El ValidatorAgent es capaz de detectar y analizar múltiples afirmaciones dentro de un mismo texto.
+> El límite máximo de caracteres permitidos se define mediante la variable de entorno VALIDATOR_MAX_INPUT_CHARS (por defecto se recomienda un máximo de 3.000 caracteres).
+> Para asegurar una evaluación óptima, evita incluir afirmaciones ambiguas o mal estructuradas en el mismo bloque de texto.
+
+### Validar múltiples afirmaciones
 
 ```bash
-curl http://localhost:3001/api/facts/verifications/last
+curl -X POST http://localhost:3001/api/validators/analyze \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "La Segunda Guerra Mundial terminó en 1945.
+               La población mundial actual ha superado los 20 mil millones de personas.
+               El Quijote fue escrito por William Shakespeare.",
+    "waitForFact": true
+}'
 ```
-
-> ⚠️ **Nota importante:** Actualmente el `ValidatorAgent` no está optimizado para analizar múltiples afirmaciones dentro de un mismo texto largo.
-> Se recomienda enviar afirmaciones **una por una** y no exceder los **3.000 caracteres** por entrada para asegurar resultados precisos.
 
 ### Obtener la última verificación factual
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -49,14 +49,22 @@ curl -X POST http://localhost:3001/api/validators/analyze \
   -d '{"prompt":"El sol es una estrella.","waitForFact":true}'
 ```
 
-### Obtener la última verificación factual
+> ℹ️ Nota importante: El ValidatorAgent es capaz de detectar y analizar múltiples afirmaciones dentro de un mismo texto.
+> El límite máximo de caracteres permitidos se define mediante la variable de entorno VALIDATOR_MAX_INPUT_CHARS (por defecto se recomienda un máximo de 3.000 caracteres).
+> Para asegurar una evaluación óptima, evita incluir afirmaciones ambiguas o mal estructuradas en el mismo bloque de texto.
+
+### Validar múltiples afirmaciones
 
 ```bash
-curl http://localhost:3001/api/facts/verifications/last
+curl -X POST http://localhost:3001/api/validators/analyze \
+  -H "Content-Type: application/json" \
+  -d '{
+    "prompt": "La Segunda Guerra Mundial terminó en 1945.
+               La población mundial actual ha superado los 20 mil millones de personas.
+               El Quijote fue escrito por William Shakespeare.",
+    "waitForFact": true
+}'
 ```
-
-> ⚠️ **Nota importante:** Actualmente el `ValidatorAgent` no está optimizado para analizar múltiples afirmaciones dentro de un mismo texto largo.
-> Se recomienda enviar afirmaciones **una por una** y no exceder los **3.000 caracteres** por entrada para asegurar resultados precisos.
 
 ### Obtener la última verificación factual
 

--- a/docs/api/core.md
+++ b/docs/api/core.md
@@ -1,5 +1,3 @@
-← Volver a [README.md](../README.md)
-
 # 📡 API – Core
 
 Todos los endpoints están prefijados con `/api`.

--- a/docs/api/facts.md
+++ b/docs/api/facts.md
@@ -1,5 +1,3 @@
-← Volver a [README.md](../README.md)
-
 # 📡 API – Core
 
 Todos los endpoints están prefijados con `/api`.

--- a/docs/api/validators.md
+++ b/docs/api/validators.md
@@ -1,5 +1,3 @@
-← Volver a [README.md](../README.md)
-
 # 📡 API – ValidatorAgent
 
 Todos los endpoints están prefijados con `/api`.

--- a/docs/flows/validation-to-factcheck.md
+++ b/docs/flows/validation-to-factcheck.md
@@ -1,5 +1,3 @@
-← Volver a [README.md](../README.md)
-
 # 🔄 Flujo Validator → FactChecker
 
 Este documento describe el flujo completo que ocurre cuando una afirmación es analizada por el ValidatorAgent y, si es necesario, verificada por el FactCheckerAgent mediante fuentes externas.

--- a/docs/setup/env-variables.md
+++ b/docs/setup/env-variables.md
@@ -1,5 +1,3 @@
-← Volver a [README.md](../README.md)
-
 # ⚙️ Variables de entorno
 
 Este documento detalla todas las variables de entorno requeridas por Veriqo, explicando su propósito y cómo deben configurarse correctamente en el archivo `.env`.

--- a/docs/setup/prerequisites.md
+++ b/docs/setup/prerequisites.md
@@ -1,5 +1,3 @@
-← Volver a [README.md](../README.md)
-
 # 🛠️ Prerrequisitos y Setup de Veriqo
 
 Este documento describe claramente los pasos y requisitos previos para instalar y ejecutar Veriqo correctamente en tu entorno local.

--- a/src/agents/fact-checker-agent/controllers/get-fact-by-claim.controller.ts
+++ b/src/agents/fact-checker-agent/controllers/get-fact-by-claim.controller.ts
@@ -1,7 +1,9 @@
 import { Controller, Post, Body } from '@nestjs/common';
 import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { plainToInstance } from 'class-transformer';
 import { ExecuteFactCheckerDto } from '../dto/execute-fact-checker.dto';
 import { GetFactByClaimService } from '../services';
+import { AgentFactDto } from '@/shared/facts/dto/agent-fact.dto';
 
 /**
  * Controlador que permite recuperar un fact previamente generado para una afirmación dada.
@@ -15,6 +17,8 @@ export class GetFactByClaimController {
 
     /**
      * Busca un fact verificado equivalente a una afirmación textual.
+     * Retorna un DTO limpio sin campos internos como `embedding`.
+     *
      * @param executeFactCheckerDto DTO con el texto del claim original.
      * @returns Fact equivalente si fue verificado previamente.
      */
@@ -28,10 +32,14 @@ export class GetFactByClaimController {
             executeFactCheckerDto,
         );
 
+        const dto = plainToInstance(AgentFactDto, result, {
+            excludeExtraneousValues: true,
+        });
+
         return {
             status: 'ok',
             message: 'Fact recuperado correctamente.',
-            data: result,
+            data: dto,
         };
     }
 }

--- a/src/agents/fact-checker-agent/controllers/get-last-verification.controller.ts
+++ b/src/agents/fact-checker-agent/controllers/get-last-verification.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get } from '@nestjs/common';
-import { ApiOperation, ApiTags } from '@nestjs/swagger';
+import { ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { GetLastVerificationService } from '../services';
+import { ExtendedFact } from '@/shared/types/extended-fact.type';
 
 /**
  * Controlador para obtener la última verificación factual registrada.
@@ -20,12 +21,44 @@ export class GetLastVerificationController {
     @ApiOperation({
         summary: 'Recupera la última verificación factual registrada.',
     })
-    async execute() {
+    @ApiResponse({
+        status: 200,
+        description: 'Verificación más reciente encontrada',
+        schema: {
+            example: {
+                status: 'ok',
+                message: 'Última verificación recuperada.',
+                data: {
+                    id: 'uuid',
+                    claim: 'La velocidad de la luz depende del observador',
+                    normalizedClaim: 'velocidad luz depende observador',
+                    status: 'false',
+                    reasoning:
+                        'La afirmación contradice la relatividad especial...',
+                    sources_retrieved: [
+                        'https://es.wikipedia.org/wiki/Velocidad_de_la_luz',
+                    ],
+                    sources_used: [
+                        'https://es.wikipedia.org/wiki/Velocidad_de_la_luz',
+                    ],
+                    createdAt: '2025-04-17T01:23:45.000Z',
+                    updatedAt: '2025-04-17T01:23:45.000Z',
+                },
+            },
+        },
+    })
+    async execute(): Promise<{
+        status: string;
+        message: string;
+        data: ExtendedFact | null;
+    }> {
         const result = await this.getLastResultService.execute();
 
         return {
             status: 'ok',
-            message: 'Última verificación recuperada.',
+            message: result
+                ? 'Última verificación recuperada.'
+                : 'No hay verificaciones aún.',
             data: result,
         };
     }

--- a/src/agents/fact-checker-agent/dto/execute-fact-checker.dto.ts
+++ b/src/agents/fact-checker-agent/dto/execute-fact-checker.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { Exclude } from 'class-transformer';
 import { IsString, MinLength, IsOptional, IsUUID } from 'class-validator';
 
 /**

--- a/src/agents/fact-checker-agent/services/get-fact-by-claim.service.ts
+++ b/src/agents/fact-checker-agent/services/get-fact-by-claim.service.ts
@@ -1,18 +1,60 @@
 import { Injectable } from '@nestjs/common';
+import { plainToInstance } from 'class-transformer';
 import { ExecuteFactCheckerDto } from '../dto/execute-fact-checker.dto';
-import { AgentFact } from '@/core/database/entities/agent-fact.entity';
+import { AgentFactDto } from '@/shared/facts/dto/agent-fact.dto';
 import { AgentFactService } from '@/shared/facts/services/agent-fact.service';
+import { AgentVerificationService } from '@/shared/facts/services/agent-verification.service';
+import { normalizeClaim } from '@/shared/utils/text/normalize-claim';
 
 /**
- * Servicio para obtener un fact previamente verificado a partir de una afirmación textual (claim).
+ * Servicio para obtener un fact previamente verificado a partir de una afirmación textual.
+ * Aplica normalización y fallback a AgentVerification si no se encuentra el fact.
  */
 @Injectable()
 export class GetFactByClaimService {
-    constructor(private readonly agentFactService: AgentFactService) {}
+    constructor(
+        private readonly agentFactService: AgentFactService,
+        private readonly verificationService: AgentVerificationService,
+    ) {}
 
+    /**
+     * Busca un `AgentFact` o, en su defecto, un `AgentVerification` para el claim proporcionado.
+     * @param executeFactCheckerDto DTO con la afirmación original.
+     * @returns DTO enriquecido si existe una verificación previa.
+     */
     async execute(
         executeFactCheckerDto: ExecuteFactCheckerDto,
-    ): Promise<AgentFact | null> {
-        return this.agentFactService.findByClaim(executeFactCheckerDto.claim);
+    ): Promise<AgentFactDto | null> {
+        const normalized = normalizeClaim(executeFactCheckerDto.claim);
+
+        const fact =
+            await this.agentFactService.findByNormalizedClaimAny(normalized);
+        if (fact) {
+            return plainToInstance(AgentFactDto, fact, {
+                excludeExtraneousValues: true,
+            });
+        }
+
+        const verification = await this.verificationService.findByClaim(
+            executeFactCheckerDto.claim,
+        );
+        if (!verification) return null;
+
+        // Construimos un DTO fake desde la verificación
+        return plainToInstance(
+            AgentFactDto,
+            {
+                id: verification.id,
+                claim: verification.claim,
+                normalizedClaim: normalized,
+                status: verification.result,
+                sourcesRetrieved: verification.sourcesRetrieved ?? [],
+                sourcesUsed: verification.sourcesUsed ?? [],
+                reasoning: verification.reasoning ?? null,
+                createdAt: verification.createdAt,
+                updatedAt: verification.updatedAt,
+            },
+            { excludeExtraneousValues: true },
+        );
     }
 }

--- a/src/agents/fact-checker-agent/services/handle-factual-check-required.service.ts
+++ b/src/agents/fact-checker-agent/services/handle-factual-check-required.service.ts
@@ -17,15 +17,10 @@ export class HandleFactualCheckRequiredService {
     async execute(
         payload: AgentEventPayload<FactualCheckRequiredEventPayload>,
     ): Promise<void> {
-        const {
-            claim,
-            context = 'context_not_provided',
-            findingId,
-        } = payload.data;
+        const { claim, findingId } = payload.data;
 
         await this.verifyClaimService.execute({
             claim,
-            context,
             findingId,
         });
     }

--- a/src/agents/validator-agent/dto/execute-validator.dto.ts
+++ b/src/agents/validator-agent/dto/execute-validator.dto.ts
@@ -7,6 +7,7 @@ import {
     Matches,
     MinLength,
 } from 'class-validator';
+import { env } from '@/config/env/env.config';
 
 /**
  * DTO para ejecutar el análisis de texto por el ValidatorAgent.
@@ -14,17 +15,18 @@ import {
 export class ExecuteValidatorDto {
     /**
      * Texto que deseas que el ValidatorAgent analice.
-     * Debe tener entre 5 y 2000 caracteres y contener al menos un carácter no vacío.
      */
     @ApiProperty({
         example: 'Pedro Gómez fue astronauta de la NASA.',
         description: 'Texto que deseas que el ValidatorAgent analice.',
         minLength: 5,
-        maxLength: 2000,
+        maxLength: env.VALIDATOR_MAX_INPUT_CHARS,
     })
     @IsString()
     @MinLength(5)
-    @MaxLength(2000)
+    @MaxLength(env.VALIDATOR_MAX_INPUT_CHARS, {
+        message: `El prompt no puede superar los ${env.VALIDATOR_MAX_INPUT_CHARS} caracteres.`,
+    })
     @Matches(/\S/, {
         message: 'El prompt no puede estar vacío o solo contener espacios.',
     })

--- a/src/agents/validator-agent/services/verify-claim.service.ts
+++ b/src/agents/validator-agent/services/verify-claim.service.ts
@@ -1,21 +1,33 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { ValidationFindingDto } from '../dto/validation-finding.dto';
+import { env } from '@/config/env/env.config';
 import { AgentFindingService } from '@/shared/facts/services/agent-finding.service';
+import { LlmRouterService } from '@/shared/llm/llm-router.service';
 
-/**
- * Servicio para verificar una afirmación textual mediante el ValidatorAgent.
- */
 @Injectable()
 export class VerifyClaimService {
-    constructor(private readonly agentFindingService: AgentFindingService) {}
+    constructor(
+        private readonly agentFindingService: AgentFindingService,
+        private readonly llmRouterService: LlmRouterService,
+    ) {}
 
     /**
-     * Ejecuta el proceso de validación sobre una afirmación (prompt).
-     * @param prompt Afirmación a validar.
+     * Ejecuta el proceso de validación sobre una o varias afirmaciones.
+     * Utiliza un único análisis completo con Claude para detectar, normalizar
+     * y categorizar múltiples afirmaciones en un solo paso.
+     *
+     * @param prompt Texto libre a analizar.
      * @returns Lista de findings generados tras el análisis.
      */
     async execute(prompt: string): Promise<ValidationFindingDto[]> {
+        if (prompt.length > env.VALIDATOR_MAX_INPUT_CHARS) {
+            throw new BadRequestException(
+                `El texto supera el límite de ${env.VALIDATOR_MAX_INPUT_CHARS} caracteres. Divide el contenido en afirmaciones más pequeñas.`,
+            );
+        }
+
         const findings = await this.agentFindingService.analyzeText(prompt);
+
         return findings.map((f) => f.mapToDto());
     }
 }

--- a/src/config/env/env.config.ts
+++ b/src/config/env/env.config.ts
@@ -40,13 +40,12 @@ export const env: {
 
     // Modelos LLM y embeddings.
     VALIDATOR_MODEL: string;
+    VALIDATOR_MAX_INPUT_CHARS: number;
     FACTCHECKER_MODEL: string;
+    FACT_CHECK_CACHE_DAYS: number;
     EMBEDDING_MODEL: string;
     EMBEDDING_MODEL_PROVIDER: string;
     EMBEDDING_SIMILARITY_THRESHOLD: number;
-
-    // Parámetros adicionales.
-    FACT_CHECK_CACHE_DAYS: number;
 } = {
     DB_TYPE: parsedEnv.data.DB_TYPE as SupportedDbType,
     DB_HOST: parsedEnv.data.DB_HOST,
@@ -68,12 +67,11 @@ export const env: {
 
     // Modelos LLM y embeddings.
     VALIDATOR_MODEL: parsedEnv.data.VALIDATOR_MODEL,
+    VALIDATOR_MAX_INPUT_CHARS: parsedEnv.data.VALIDATOR_MAX_INPUT_CHARS,
     FACTCHECKER_MODEL: parsedEnv.data.FACTCHECKER_MODEL,
+    FACT_CHECK_CACHE_DAYS: parsedEnv.data.FACT_CHECK_CACHE_DAYS ?? 7,
     EMBEDDING_MODEL: parsedEnv.data.EMBEDDING_MODEL,
     EMBEDDING_MODEL_PROVIDER: parsedEnv.data.EMBEDDING_MODEL_PROVIDER,
     EMBEDDING_SIMILARITY_THRESHOLD:
         parsedEnv.data.EMBEDDING_SIMILARITY_THRESHOLD ?? 0.8,
-
-    // Parámetros adicionales.
-    FACT_CHECK_CACHE_DAYS: parsedEnv.data.FACT_CHECK_CACHE_DAYS ?? 7,
 };

--- a/src/config/env/env.validation.ts
+++ b/src/config/env/env.validation.ts
@@ -31,9 +31,11 @@ export const envSchema = z.object({
 
     // Modelos LLM y embeddings.
     VALIDATOR_MODEL: z.string().min(1, 'VALIDATOR_MODEL no puede estar vacío'),
+    VALIDATOR_MAX_INPUT_CHARS: z.coerce.number().default(3000),
     FACTCHECKER_MODEL: z
         .string()
         .min(1, 'FACTCHECKER_MODEL no puede estar vacío'),
+    FACT_CHECK_CACHE_DAYS: z.coerce.number().int().min(1).default(7),
     EMBEDDING_MODEL: z.string().min(1, 'EMBEDDING_MODEL no puede estar vacío'),
     EMBEDDING_MODEL_PROVIDER: z
         .string()
@@ -43,9 +45,6 @@ export const envSchema = z.object({
         .min(0.0, 'Debe ser >= 0.0')
         .max(1.0, 'Debe ser <= 1.0')
         .default(0.8),
-
-    // Parámetros adicionales.
-    FACT_CHECK_CACHE_DAYS: z.coerce.number().int().min(1).default(7),
 });
 
 export type EnvSchema = z.infer<typeof envSchema>;

--- a/src/core/controllers/get-prompt-by-agent.controller.ts
+++ b/src/core/controllers/get-prompt-by-agent.controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Get, Param } from '@nestjs/common';
-import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { Controller, Get, Param, Query } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { AgentPromptService } from '@/shared/prompts/agent-prompt.service';
 
 /**
- * Devuelve el prompt asociado a un agente específico.
+ * Devuelve el prompt asociado a un agente y clave específica.
  */
 @ApiTags('Core')
 @Controller('core')
@@ -11,14 +11,20 @@ export class GetPromptByAgentController {
     constructor(private readonly promptService: AgentPromptService) {}
 
     /**
-     * Recupera el prompt asignado al agente especificado.
+     * Recupera un prompt concreto asignado a un agente y clave.
+     *
      * @param agent Nombre del agente (ej. 'validator_agent').
+     * @param key Clave del prompt (ej. 'VALIDATOR_ANALYZE_MULTICLAIM').
      */
     @Get('prompts/:agent')
-    @ApiOperation({ summary: 'Obtiene el prompt de un agente específico.' })
+    @ApiOperation({
+        summary:
+            'Obtiene el prompt dinámico de un agente específico por clave.',
+    })
     @ApiParam({ name: 'agent', example: 'validator_agent' })
-    async execute(@Param('agent') agent: string) {
-        const prompt = await this.promptService.findPromptByAgent(agent);
+    @ApiQuery({ name: 'key', example: 'VALIDATOR_ANALYZE_MULTICLAIM' })
+    async execute(@Param('agent') agent: string, @Query('key') key: string) {
+        const prompt = await this.promptService.getPrompt(agent, key);
 
         return {
             status: 'ok',

--- a/src/core/database/entities/agent-fact.entity.ts
+++ b/src/core/database/entities/agent-fact.entity.ts
@@ -1,91 +1,38 @@
-import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import { ApiProperty } from '@nestjs/swagger';
 import {
-    Entity,
-    PrimaryGeneratedColumn,
     Column,
     CreateDateColumn,
+    Entity,
+    PrimaryGeneratedColumn,
     UpdateDateColumn,
-    Index,
 } from 'typeorm';
-import { VerificationVerdict } from '@/shared/types/verification-verdict.type';
 
 @Entity('agent_facts')
 export class AgentFact {
-    @ApiProperty({ example: 'bbde9314-5011-46e0-aea1-f4bcae91e5c3' })
+    @ApiProperty()
     @PrimaryGeneratedColumn('uuid')
-    readonly id: string;
+    id: string;
 
-    @ApiProperty({
-        example: 'La velocidad de la luz depende del observador',
-        description: 'Afirmación original que fue verificada por el agente.',
-    })
-    @Column({ name: 'claim', type: 'varchar', length: 512 })
+    @ApiProperty()
+    @Column({ type: 'text' })
     claim: string;
 
-    @ApiProperty({
-        description:
-            'Versión normalizada del claim, útil para comparación semántica y evitar duplicados.',
-        example: 'velocidad luz depende observador',
-    })
-    @Index('IDX_agent_fact_normalized_claim')
-    @Column({
-        type: 'varchar',
-        length: 255,
-        name: 'normalized_claim',
-        nullable: true,
-    })
-    normalizedClaim?: string;
+    @ApiProperty()
+    @Column({ name: 'normalized_claim', type: 'text' })
+    normalizedClaim: string;
 
-    @ApiHideProperty()
-    @Column({
-        type: 'json',
-        nullable: true,
-    })
+    @Column({ name: 'embedding', type: 'simple-json', nullable: true })
     embedding?: number[];
 
-    @ApiProperty({
-        example: 'false',
-        enum: ['true', 'false', 'possibly_true', 'unknown'],
-        description: 'Resultado de la verificación factual.',
-    })
-    @Column({
-        name: 'status',
-        type: 'enum',
-        enum: ['true', 'false', 'possibly_true', 'unknown'],
-    })
-    status: VerificationVerdict;
+    @ApiProperty({ enum: ['true', 'false', 'possibly_true', 'unknown'] })
+    @Column({ type: 'varchar', length: 32 })
+    status: string;
 
-    @ApiProperty({
-        type: [String],
-        example: ['https://es.wikipedia.org/wiki/Velocidad_de_la_luz'],
-        description:
-            'Fuentes mencionadas durante el análisis factual (declaradas).',
-    })
-    @Column('json', { nullable: true })
-    sources?: string[];
-
-    @ApiProperty({
-        type: [String],
-        example: ['https://es.wikipedia.org/wiki/Velocidad_de_la_luz'],
-        description: 'Fuentes principales utilizadas para tomar la decisión.',
-    })
-    @Column('json', { name: 'sources_used', nullable: true })
-    sourcesUsed?: string[];
-
-    @ApiProperty({
-        description:
-            'Razonamiento generado por el agente sobre la veracidad del claim.',
-        example:
-            'La mayoría de fuentes indican que la velocidad de la luz es constante...',
-    })
-    @Column({ type: 'text', name: 'reasoning', nullable: true })
-    reasoning?: string;
-
-    @ApiProperty({ example: '2025-04-16T23:41:23.430Z' })
+    @ApiProperty()
     @CreateDateColumn({ name: 'created_at' })
-    readonly createdAt: Date;
+    createdAt: Date;
 
-    @ApiProperty({ example: '2025-04-16T23:41:23.430Z' })
+    @ApiProperty()
     @UpdateDateColumn({ name: 'updated_at' })
-    readonly updatedAt: Date;
+    updatedAt: Date;
 }

--- a/src/core/database/entities/agent-prompt.entity.ts
+++ b/src/core/database/entities/agent-prompt.entity.ts
@@ -5,6 +5,7 @@ import {
     Entity,
     PrimaryGeneratedColumn,
     UpdateDateColumn,
+    Index,
 } from 'typeorm';
 
 @Entity('agent_prompts')
@@ -16,6 +17,15 @@ export class AgentPrompt {
     @ApiProperty({ example: 'validator_agent' })
     @Column({ name: 'agent', type: 'varchar', length: 64 })
     agent: string;
+
+    @ApiProperty({
+        example: 'VALIDATOR_ANALYZE_MULTICLAIM',
+        description:
+            'Clave única para identificar el tipo de prompt dentro del agente.',
+    })
+    @Index()
+    @Column({ name: 'key', type: 'varchar', length: 64 })
+    key: string;
 
     @ApiProperty({ description: 'Instrucción base del agente.' })
     @Column({ name: 'prompt', type: 'text' })

--- a/src/core/database/entities/agent-source.entity.ts
+++ b/src/core/database/entities/agent-source.entity.ts
@@ -6,10 +6,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
     Index,
-    ManyToOne,
-    JoinColumn,
 } from 'typeorm';
-import { AgentVerification } from './agent-verification.entity';
 
 @Entity('agent_sources')
 @Index(['claim'])
@@ -17,6 +14,10 @@ export class AgentSource {
     @ApiProperty({ example: 'bbde9314-5011-46e0-aea1-f4bcae91e5c3' })
     @PrimaryGeneratedColumn('uuid')
     readonly id: string;
+
+    @ApiProperty({ example: 'e9c94c7f-3f7b-4d6f-9c21-0fd8aa6c4fd7' })
+    @Column({ name: 'verification_id', type: 'uuid' })
+    verificationId: string;
 
     @ApiProperty({ example: 'fact_checker_agent' })
     @Column({ type: 'varchar', length: 64 })
@@ -46,12 +47,6 @@ export class AgentSource {
     })
     @Column({ type: 'text', nullable: true })
     snippet: string | null;
-
-    @ManyToOne(() => AgentVerification, (v) => v.sources, {
-        onDelete: 'CASCADE',
-    })
-    @JoinColumn({ name: 'verification_id' })
-    verification: AgentVerification;
 
     @ApiProperty({ example: '2025-04-16T23:41:23.430Z' })
     @CreateDateColumn({ name: 'created_at' })

--- a/src/core/database/entities/agent-verification.entity.ts
+++ b/src/core/database/entities/agent-verification.entity.ts
@@ -6,9 +6,7 @@ import {
     PrimaryGeneratedColumn,
     UpdateDateColumn,
     Index,
-    OneToMany,
 } from 'typeorm';
-import { AgentSource } from './agent-source.entity';
 
 @Entity('agent_verifications')
 @Index(['claim'])
@@ -47,9 +45,10 @@ export class AgentVerification {
         description:
             'Explicación generada por el modelo para justificar la veracidad.',
         example: 'La afirmación coincide con resultados en LinkedIn y GitHub.',
+        nullable: true,
     })
-    @Column('text')
-    reasoning: string;
+    @Column('text', { nullable: true })
+    reasoning: string | null;
 
     @ApiProperty({
         type: [String],
@@ -67,11 +66,6 @@ export class AgentVerification {
     })
     @Column('simple-array', { name: 'sources_used', nullable: true })
     sourcesUsed?: string[];
-
-    @OneToMany(() => AgentSource, (source) => source.verification, {
-        cascade: true,
-    })
-    sources: AgentSource[];
 
     @ApiProperty({ example: '2025-04-16T23:41:23.430Z' })
     @CreateDateColumn({ name: 'created_at' })

--- a/src/core/database/seeders/prompt.seeder.ts
+++ b/src/core/database/seeders/prompt.seeder.ts
@@ -13,121 +13,153 @@ export class PromptSeeder implements OnApplicationBootstrap {
     ) {}
 
     async onApplicationBootstrap(): Promise<void> {
-        const embeddingPrompt = `
-            Eres un sistema que convierte frases o afirmaciones en vectores numéricos (embeddings) para comparación semántica.
-            Devuelve únicamente un array de números en formato JSON válido, sin explicaciones. Longitud ideal: entre 128 y 512 elementos. Usa el mismo orden de tokens siempre que la frase sea equivalente.
-        `.trim();
-
-        const validatorPrompt = `
-            Eres un agente de validación experto. Tu misión es analizar textos y detectar afirmaciones incorrectas, dudosas, simplificadas, ambiguas o difíciles de verificar. Solo debes generar findings cuando realmente haya una afirmación objetiva que requiera revisión.
-
-            Tu tarea:
-
-            1. Identifica afirmaciones relevantes.
-            2. Clasifícalas según tipo de posible problema:
-                - "factual_error"
-                - "reasoning"
-                - "ambiguity"
-                - "contradiction"
-                - "style"
-                - "other"
-            3. Decide si la afirmación puede resolverse con conocimiento general.
-            4. Marca "needsFactCheck: true" solo si el modelo no puede verificarla con certeza razonable o si requiere fuentes externas.
-            5. EXTRA IMPORTANTE: Añade una propiedad adicional llamada "normalizedClaim" que represente la afirmación de forma canónica, unificada y sin adornos. Es la versión que usarás para comparar si ya fue verificada antes. Normalízala semánticamente, no solo sintácticamente. Usa nombres completos, estructuras estándar y sinónimos bien elegidos. No elimines contexto necesario.
-
-            Reglas clave:
-
-            - Si el input es una pregunta (empieza con "¿", termina con "?"), ignórala. No es una afirmación.
-            - No generes findings si el contenido es claramente verdadero, trivial o general.
-            - Si se afirma algo sobre personas no públicas o información privada (ocupación, relaciones, empresas pequeñas), marca "needsFactCheck: true".
-            - Si la afirmación contiene errores históricos, científicos o tecnológicos ampliamente conocidos (ej. fundadores de Google, leyes físicas, exploraciones europeas), el modelo debe resolverlo sin necesidad de verificación externa.
-            - No marques "needsFactCheck: true" si el modelo puede corregir la afirmación con conocimiento general, histórico, científico o de sentido común ampliamente aceptado (por ejemplo, en temas de biología, salud, comportamiento, geografía, exploración, tecnología o figuras conocidas).
-            - Si detectas simplificaciones históricas, errores lógicos o afirmaciones vagas, indícalo y sugiere reformulación.
-            - Si una afirmación es subjetiva, vaga o imposible de definir objetivamente (ej. "el mejor", "muy bueno"), márcala como "ambiguity", pero no como "needsFactCheck: true".
-            - Si una afirmación menciona hechos que ocurren en el futuro o en fechas recientes (por ejemplo, 2024–2025), y el modelo **no puede confirmar con certeza que sean falsos**, márcalo como "needsFactCheck": true. Esto es especialmente importante porque los modelos como GPT-4o o Claude pueden no tener información actualizada. Aunque la afirmación parezca razonable, no se debe asumir su veracidad sin verificación externa.
-            - Usa "reasoning" o "factual_error" para afirmaciones privadas no verificables. Reserva "other" solo para casos que no encajen claramente en ninguna categoría.
-            - No marques como problemático algo solo por sonar raro: debe haber un motivo claro.
-            - Si no puedes generar una buena "searchQuery", déjala vacía.
-
-            IMPORTANTE: Tu salida debe ser únicamente un objeto JSON válido. No escribas explicaciones externas, disculpas ni texto adicional fuera del JSON. No uses Markdown ni lenguaje natural. Solo el JSON que se especifica más abajo.
-
-            Formato de salida:
-
+        const prompts: Partial<AgentPrompt>[] = [
             {
-            "status": "ok",
-            "message": "Texto analizado correctamente.",
-            "data": [
-                {
-                "claim": "...",
-                "normalizedClaim": "...",
-                "category": "...",
-                "summary": "...",
-                "explanation": "...",
-                "suggestion": "...",
-                "keywords": [...],
-                "synonyms": { ... },
-                "namedEntities": [...],
-                "locations": [...],
-                "searchQuery": "...",
-                "siteSuggestions": [...],
-                "needsFactCheck": true | false,
-                "needsFactCheckReason": "..."
-                }
-            ]
-            }
-        `.trim();
+                agent: 'embedding_service',
+                key: 'EMBEDDING_VECTORIZE',
+                purpose: 'principal',
+                prompt: `
+                    ---SYSTEM---
+                    Eres un sistema que convierte frases o afirmaciones en vectores numéricos (embeddings) para comparación semántica.
+                    Devuelve únicamente un array de números en formato JSON válido, sin explicaciones. Longitud ideal: entre 128 y 512 elementos. Usa el mismo orden de tokens siempre que la frase sea equivalente.
 
-        const factPrompt = `
-            Eres un agente verificador experto. Tu misión es analizar si una afirmación textual es verdadera, falsa, posiblemente verdadera o desconocida, usando exclusivamente las fuentes proporcionadas. No puedes inferir, suponer ni improvisar: toda conclusión debe basarse en evidencia suficiente y directa.
-
-            Criterios para el campo "status":
-
-            - Usa "true" si al menos una fuente respalda claramente la afirmación con datos consistentes y verificables.
-            - Usa "possibly_true" si:
-            - La afirmación coincide sustancialmente con el contenido de las fuentes, aunque haya diferencias menores.
-            - No se afirma de forma literal, pero hay coincidencia contextual fuerte (ej. un perfil técnico público asociado al nombre y actividad relevante).
-            - Usa "false" solo si:
-            - Las fuentes contradicen directamente el núcleo de la afirmación (por ejemplo, nombran a otra persona como ganadora, autor real, entidad distinta, etc.).
-            - Hay evidencia clara, específica y verificable de que el hecho es incorrecto.
-            - Usa "unknown" si:
-            - No se encuentra evidencia suficiente a favor ni en contra.
-            - Las coincidencias son solo nominales o ambiguas.
-            - Se trata de un hecho no documentado públicamente.
-
-            Reglas adicionales:
-
-            - No marques "false" solo porque algo no aparece en las fuentes.
-            - No marques "true" si falta evidencia clara y directa para todos los elementos clave del claim.
-            - Marca "possibly_true" si el nombre completo aparece vinculado a actividad profesional o técnica relevante en perfiles públicos (por ejemplo, repositorios con contenido de programación, descripciones de rol técnico en LinkedIn, blogs personales con artículos del sector, etc.), aunque no haya una afirmación literal.
-            - Asegúrate de que no exista ambigüedad con otras personas de nombre similar en contextos distintos.
-            - Marca "false" si una fuente confiable contradice explícitamente el hecho central de la afirmación (ej. otro ganador, otra fecha, negación directa).
-            - Marca "unknown" si las coincidencias se limitan al nombre, sin contexto verificable adicional.
-
-            Formato de salida obligatorio (sin comentarios ni markdown):
-
+                    ---USER---
+                    {{text}}
+                `.trim(),
+            },
             {
-                "status": "true" | "false" | "possibly_true" | "unknown",
-                "reasoning": "Explicación clara basada únicamente en las fuentes.",
-                "sources_used": ["https://...", "https://..."]
-            }
-        `.trim();
+                agent: 'validator_agent',
+                key: 'VALIDATOR_ANALYZE_MULTICLAIM',
+                purpose: 'principal',
+                prompt: `
+                    ---SYSTEM---
+                    Eres un agente de validación experto.
 
-        const prompts = [
-            { agent: 'embedding_service', prompt: embeddingPrompt },
-            { agent: 'validator_agent', prompt: validatorPrompt },
-            { agent: 'fact_checker_agent', prompt: factPrompt },
+                    Tu objetivo es analizar un texto que puede contener múltiples afirmaciones. Por cada afirmación objetiva que detectes, debes generar un objeto estructurado que identifique posibles problemas de veracidad, claridad o lógica.
+
+                    Tu tarea, por cada afirmación detectada:
+
+                    1. Extrae la afirmación exacta del texto original.
+                    2. Clasifícala en una de estas categorías de problema:
+                        - "factual_error"
+                        - "reasoning"
+                        - "ambiguity"
+                        - "contradiction"
+                        - "style"
+                        - "other"
+                    3. Decide si puede verificarse con conocimiento general.
+                    4. Marca "needsFactCheck: true" solo si no puedes validarla internamente con suficiente certeza, o si requiere fuentes externas.
+                    5. Genera "normalizedClaim": la versión canónica de la afirmación, limpia, directa, semánticamente clara, y adecuada para buscar equivalencias en base de datos. Usa sinónimos comunes, nombres completos, estructura estándar y sin adornos innecesarios.
+
+                    Reglas clave:
+
+                    - Ignora preguntas (empiezan con "¿", terminan con "?").
+                    - No generes findings sobre afirmaciones claramente verdaderas, triviales o genéricas.
+                    - Marca como "needsFactCheck: true" afirmaciones sobre personas no públicas o datos privados.
+                    - Si el modelo puede corregir una afirmación con conocimientos generales (historia, ciencia, geografía...), NO marques como "needsFactCheck".
+                    - Si no puedes verificar con certeza hechos recientes o futuros (ej. entre 2024–2025), márcalos como "needsFactCheck": true.
+                    - Usa "ambiguity" para afirmaciones subjetivas, vagas o sin marco verificable.
+                    - Usa "reasoning" para errores lógicos.
+                    - Usa "factual_error" si la afirmación es objetivamente incorrecta.
+                    - Usa "other" solo si no encaja en ninguna categoría anterior.
+                    - Si no puedes generar un buen "searchQuery", déjala vacía.
+
+                    Formato de salida:
+
+                    Devuelve exclusivamente un objeto JSON con esta estructura, y nada más:
+
+                    {
+                        "status": "ok",
+                        "message": "Texto analizado correctamente.",
+                        "data": [
+                        {
+                            "claim": "...",
+                            "normalizedClaim": "...",
+                            "category": "...",
+                            "summary": "...",
+                            "explanation": "...",
+                            "suggestion": "...",
+                            "keywords": [...],
+                            "synonyms": { ... },
+                            "namedEntities": [...],
+                            "locations": [...],
+                            "searchQuery": "...",
+                            "siteSuggestions": [...],
+                            "needsFactCheck": true | false,
+                            "needsFactCheckReason": "..."
+                        },
+                        ...
+                        ]
+                    }
+
+                    Importante:
+
+                    - Un objeto en "data" por cada afirmación encontrada.
+                    - No incluyas texto explicativo fuera del JSON.
+                    - No uses Markdown ni lenguaje natural.
+
+                    ---USER---
+                    {{text}}
+              `.trim(),
+            },
+            {
+                agent: 'fact_checker_agent',
+                key: 'FACTCHECK_ANALYZE_STATUS',
+                purpose: 'principal',
+                prompt: `
+                    ---SYSTEM---
+                    Eres un agente verificador experto. Tu misión es analizar si una afirmación textual es verdadera, falsa, posiblemente verdadera o desconocida, usando exclusivamente las fuentes proporcionadas. No puedes inferir, suponer ni improvisar: toda conclusión debe basarse en evidencia suficiente y directa.
+
+                    Criterios para el campo "status":
+
+                    - Usa "true" si al menos una fuente respalda claramente la afirmación con datos consistentes y verificables.
+                    - Usa "possibly_true" si:
+                        - La afirmación coincide sustancialmente con el contenido de las fuentes, aunque haya diferencias menores.
+                        - No se afirma de forma literal, pero hay coincidencia contextual fuerte (ej. un perfil técnico público asociado al nombre y actividad relevante).
+                    - Usa "false" solo si:
+                        - Las fuentes contradicen directamente el núcleo de la afirmación.
+                        - Hay evidencia clara y verificable de que el hecho es incorrecto.
+                    - Usa "unknown" si:
+                        - No se encuentra evidencia suficiente a favor ni en contra.
+                        - Las coincidencias son nominales o ambiguas.
+
+                    Reglas adicionales:
+
+                    - No marques "false" solo porque algo no aparece en las fuentes.
+                    - No marques "true" si falta evidencia clara y directa para todos los elementos clave del claim.
+                    - Marca "possibly_true" si el nombre completo aparece vinculado a actividad profesional o técnica relevante.
+                    - Asegúrate de que no exista ambigüedad con otras personas de nombre similar.
+                    - Marca "false" si una fuente confiable contradice explícitamente el hecho.
+                    - Marca "unknown" si las coincidencias se limitan al nombre, sin contexto verificable adicional.
+
+                    Formato de salida obligatorio (sin comentarios ni markdown):
+
+                    {
+                        "status": "true" | "false" | "possibly_true" | "unknown",
+                        "reasoning": "Explicación clara basada únicamente en las fuentes.",
+                        "sources_used": ["https://...", "https://..."]
+                    }
+
+                    ---USER---
+                    {{text}}
+                `.trim(),
+            },
         ];
 
-        for (const { agent, prompt } of prompts) {
-            const existing = await this.promptRepo.findOneBy({ agent });
+        for (const promptData of prompts) {
+            const existing = await this.promptRepo.findOneBy({
+                agent: promptData.agent,
+                key: promptData.key,
+            });
 
             await this.promptRepo.save({
                 ...existing,
-                agent,
-                prompt,
+                ...promptData,
             });
 
-            console.log(`[PromptSeeder] Prompt actualizado para '${agent}'`);
+            this.logger.log(
+                `[PromptSeeder] Prompt actualizado para '${promptData.agent}' [${promptData.key}]`,
+            );
         }
     }
 }

--- a/src/shared/events/event-bus.service.ts
+++ b/src/shared/events/event-bus.service.ts
@@ -3,8 +3,13 @@ import { EventEmitter2 } from '@nestjs/event-emitter';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentEventPayload } from './types/agent-event-payload.type';
+import { AgentEventType } from './types/agent-event-type.enum';
 import { AgentEvent } from '@/core/database/entities/agent-event.entity';
 
+/**
+ * Servicio centralizado para la emisión, persistencia y suscripción a eventos entre agentes.
+ * Permite registrar listeners personalizados por tipo de evento.
+ */
 @Injectable()
 export class EventBusService {
     constructor(
@@ -14,8 +19,33 @@ export class EventBusService {
     ) {}
 
     /**
+     * Mapa interno de listeners registrados por tipo de evento.
+     */
+    private readonly subscribers = new Map<
+        AgentEventType,
+        ((payload: any) => void | Promise<void>)[]
+    >();
+
+    /**
+     * Registra un listener para un tipo de evento específico.
+     * @param type Tipo de evento que se quiere escuchar.
+     * @param handler Función que se ejecutará cuando el evento sea emitido.
+     */
+    on<T>(
+        type: AgentEventType,
+        handler: (payload: T) => void | Promise<void>,
+    ): void {
+        if (!this.subscribers.has(type)) {
+            this.subscribers.set(type, []);
+        }
+        this.subscribers.get(type)!.push(handler);
+    }
+
+    /**
      * Emite un evento a otros agentes y lo guarda en base de datos.
-     * @param payload Datos del evento a emitir
+     * También dispara los listeners registrados manualmente mediante `.on(...)`.
+     *
+     * @param payload Datos del evento a emitir.
      */
     async emitEvent<T extends Record<string, any>>(
         payload: AgentEventPayload<T>,
@@ -27,7 +57,21 @@ export class EventBusService {
         });
 
         await this.eventRepo.save(eventEntity);
-        this.eventEmitter.emit(payload.type, payload);
+
+        // Disparar listeners registrados manualmente
+        const handlers = this.subscribers.get(payload.type as AgentEventType);
+
+        if (handlers) {
+            for (const handler of handlers) {
+                try {
+                    await handler(payload.data);
+                } catch (err) {
+                    console.error(
+                        `[EventBusService] Error en handler de ${payload.type}: ${err.message}`,
+                    );
+                }
+            }
+        }
     }
 
     /**
@@ -39,7 +83,7 @@ export class EventBusService {
 
     /**
      * Marca como procesado un evento específico asociado a un hallazgo (finding).
-     * @param findingId ID del hallazgo relacionado
+     * @param findingId ID del hallazgo relacionado.
      */
     async markAsProcessedByFindingId(findingId: string): Promise<void> {
         if (!findingId) return;

--- a/src/shared/facts/dto/agent-fact.dto.ts
+++ b/src/shared/facts/dto/agent-fact.dto.ts
@@ -1,0 +1,44 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+
+@Exclude()
+export class AgentFactDto {
+    @ApiProperty()
+    @Expose()
+    id: string;
+
+    @ApiProperty()
+    @Expose()
+    claim: string;
+
+    @ApiProperty()
+    @Expose()
+    normalizedClaim: string;
+
+    @Expose()
+    @ApiProperty({ enum: ['true', 'false', 'possibly_true', 'unknown'] })
+    status: string;
+
+    @ApiProperty({ type: [String] })
+    @Expose()
+    sourcesRetrieved: string[];
+
+    @ApiProperty({ type: [String], nullable: true })
+    @Expose()
+    sourcesUsed: string[] | null;
+
+    @ApiProperty({ nullable: true })
+    @Expose()
+    reasoning: string | null;
+
+    @ApiProperty()
+    @Expose()
+    createdAt: Date;
+
+    @ApiProperty()
+    @Expose()
+    updatedAt: Date;
+
+    @Exclude()
+    embedding?: number[];
+}

--- a/src/shared/facts/services/agent-verification.service.ts
+++ b/src/shared/facts/services/agent-verification.service.ts
@@ -59,12 +59,12 @@ export class AgentVerificationService {
 
         const sourceEntities = sources.map((source) =>
             this.sourceRepo.create({
+                verificationId: savedVerification.id,
                 agent,
                 claim,
                 url: source.url,
                 domain: source.domain,
                 snippet: source.snippet ?? null,
-                verification: savedVerification,
             }),
         );
 
@@ -79,7 +79,6 @@ export class AgentVerificationService {
     async findByClaim(claim: string): Promise<AgentVerification | null> {
         return this.verificationRepo.findOne({
             where: { claim },
-            relations: ['sources'],
         });
     }
 

--- a/src/shared/facts/services/claim-normalize.service.ts
+++ b/src/shared/facts/services/claim-normalize.service.ts
@@ -18,7 +18,7 @@ export class ClaimNormalizerService {
      * @returns Forma normalizada del claim (ej: "pedro astronauta").
      */
     async normalize(claim: string): Promise<string> {
-        const response = await this.llmRouter.normalizeClaim(claim);
+        const response = await this.llmRouter.normalizeClaimWithLlm(claim);
         return response.normalizedClaim;
     }
 }

--- a/src/shared/llm/llm-router.service.ts
+++ b/src/shared/llm/llm-router.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, InternalServerErrorException } from '@nestjs/common';
 import { ChatCompletionMessageParam } from 'openai/resources/chat';
 import { ClaudeChatService } from './claude-chat.service';
 import { OpenAIChatService } from './openai-chat.service';
 import { ClaudeEmbeddingService } from '../embeddings/claude-embedding.service';
 import { OpenAIEmbeddingService } from '../embeddings/openai-embedding.service';
+import { AgentPromptService } from '../prompts/agent-prompt.service';
 import { env } from '@/config/env/env.config';
 
 @Injectable()
@@ -13,6 +14,7 @@ export class LlmRouterService {
         private readonly openai: OpenAIChatService,
         private readonly openaiEmbedding: OpenAIEmbeddingService,
         private readonly claudeEmbedding: ClaudeEmbeddingService,
+        private readonly promptService: AgentPromptService,
     ) {}
 
     /**
@@ -43,11 +45,86 @@ export class LlmRouterService {
     }
 
     /**
+     * Analiza un texto que puede contener múltiples afirmaciones, usando Claude
+     * con prompt estructurado en bloques `system` y `user` separados por delimitadores.
+     *
+     * El prompt debe incluir las secciones `---SYSTEM---` y `---USER---` para separar
+     * instrucciones globales del contenido dinámico.
+     *
+     * @param text Texto libre a analizar.
+     * @returns JSON plano con findings generados por Claude.
+     * @throws Error si el prompt no tiene el formato esperado.
+     */
+    async validateMultipleClaims(text: string): Promise<string> {
+        const promptEntry = await this.promptService.getPrompt(
+            'validator_agent',
+            'VALIDATOR_ANALYZE_MULTICLAIM',
+        );
+
+        const rawPrompt = promptEntry.prompt;
+
+        if (
+            !rawPrompt.includes('---SYSTEM---') ||
+            !rawPrompt.includes('---USER---')
+        ) {
+            throw new Error(
+                `El prompt con key '${promptEntry.key}' no tiene el formato esperado con bloques '---SYSTEM---' y '---USER---'.`,
+            );
+        }
+
+        const [_, promptBody] = rawPrompt.split('---SYSTEM---');
+        const [systemBlock, userBlock] = promptBody.split('---USER---');
+
+        const messages: ChatCompletionMessageParam[] = [
+            {
+                role: 'system',
+                content: systemBlock.trim(),
+            },
+            {
+                role: 'user',
+                content: userBlock.replace('{{text}}', text).trim(),
+            },
+        ];
+
+        const content = await this.claude.chat(messages, env.VALIDATOR_MODEL);
+        return content;
+    }
+
+    /**
+     * Normaliza una afirmación textual usando el prompt configurado desde base de datos.
+     *
+     * Utiliza el modelo del ValidatorAgent para transformar la afirmación original
+     * en una versión canónica, clara y uniforme.
+     *
+     * @param claim Afirmación a normalizar.
+     * @returns Objeto con la afirmación normalizada.
+     */
+    async normalizeClaimWithLlm(
+        claim: string,
+    ): Promise<{ normalizedClaim: string }> {
+        const promptEntry = await this.promptService.getPrompt(
+            'validator_agent',
+            'VALIDATOR_NORMALIZE_CLAIM',
+        );
+
+        const prompt = promptEntry.prompt.replace('{{claim}}', claim);
+
+        const content = await this.claude.chat(
+            [{ role: 'user', content: prompt }],
+            env.VALIDATOR_MODEL,
+        );
+
+        return {
+            normalizedClaim: content.trim().replace(/^"|"$/g, ''),
+        };
+    }
+
+    /**
      * Genera un embedding numérico a partir de texto, usando el proveedor configurado.
      *
-     * @param text Texto a convertir
-     * @param model Modelo de embedding (por defecto: 'text-embedding-3-small')
-     * @returns Vector de embedding (array de floats)
+     * @param text Texto a convertir.
+     * @param model Modelo de embedding (por defecto: 'text-embedding-3-small').
+     * @returns Vector de embedding (array de floats).
      */
     async embed(
         text: string,
@@ -71,29 +148,5 @@ export class LlmRouterService {
         throw new Error(
             `Proveedor de embedding no soportado: ${provider}. Usa 'openai' o 'claude'.`,
         );
-    }
-
-    /**
-     * Normaliza una afirmación textual usando el modelo configurado del ValidatorAgent.
-     * Extrae su forma canónica o estándar para comparar equivalencias semánticas.
-     */
-    async normalizeClaim(claim: string): Promise<{ normalizedClaim: string }> {
-        const messages: ChatCompletionMessageParam[] = [
-            {
-                role: 'system',
-                content:
-                    'Eres un agente que transforma afirmaciones ambiguas o redundantes en versiones claras, breves y canónicas.',
-            },
-            {
-                role: 'user',
-                content: `Normaliza esta afirmación para verificar duplicados:\n\n"${claim}"\n\nSolo devuelve la frase normalizada.`,
-            },
-        ];
-
-        const content = await this.chatWithAgent('validator', messages);
-
-        return {
-            normalizedClaim: content.trim().replace(/^"|"$/g, ''),
-        };
     }
 }

--- a/src/shared/prompts/agent-prompt.service.ts
+++ b/src/shared/prompts/agent-prompt.service.ts
@@ -1,5 +1,4 @@
-import { Injectable } from '@nestjs/common';
-import { NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { AgentEvent } from '@/core/database/entities/agent-event.entity';
@@ -14,24 +13,38 @@ export class AgentPromptService {
         private readonly eventRepo: Repository<AgentEvent>,
     ) {}
 
-    async findPromptByAgent(agent: string): Promise<string> {
-        const prompt = await this.promptRepo.findOneBy({ agent });
+    /**
+     * Recupera un prompt específico desde base de datos, según agente y clave.
+     *
+     * @param agent Nombre del agente (ej: 'validator_agent').
+     * @param key Clave del prompt (ej: 'VALIDATOR_NORMALIZE_CLAIM').
+     * @returns Objeto AgentPrompt con el contenido del prompt.
+     * @throws NotFoundException si no existe.
+     */
+    async getPrompt(agent: string, key: string): Promise<AgentPrompt> {
+        const prompt = await this.promptRepo.findOneBy({ agent, key });
 
         if (!prompt) {
             throw new NotFoundException(
-                `No se encontró el prompt para el agente "${agent}"`,
+                `No se encontró el prompt para el agente '${agent}' con la clave '${key}'.`,
             );
         }
 
-        return prompt.prompt;
+        return prompt;
     }
 
+    /**
+     * Devuelve todos los prompts disponibles, ordenados por agente.
+     */
     async findAllPrompts(): Promise<AgentPrompt[]> {
         return this.promptRepo.find({
             order: { agent: 'ASC' },
         });
     }
 
+    /**
+     * Devuelve todos los eventos registrados, ordenados cronológicamente.
+     */
     async findAllEvents(): Promise<AgentEvent[]> {
         return this.eventRepo.find({ order: { createdAt: 'DESC' } });
     }

--- a/src/shared/types/extended-fact.type.ts
+++ b/src/shared/types/extended-fact.type.ts
@@ -15,18 +15,16 @@ export class ExtendedFact {
     normalizedClaim?: string;
 
     @ApiProperty({
-        example: ['https://es.wikipedia.org/wiki/Velocidad_de_la_luz'],
-    })
-    sources: string[];
-
-    @ApiProperty({
         example: 'false',
         enum: ['true', 'false', 'possibly_true', 'unknown'],
     })
     status: VerificationVerdict;
 
-    @ApiProperty({ example: 'Explicación generada por el agente' })
-    reasoning: string;
+    @ApiProperty({
+        description: 'Explicación generada por el agente',
+        nullable: true,
+    })
+    reasoning: string | null;
 
     @ApiProperty({ type: [String] })
     sources_retrieved: string[];

--- a/src/shared/types/fact-checker-result.type.ts
+++ b/src/shared/types/fact-checker-result.type.ts
@@ -7,9 +7,8 @@ export type FactCheckerResult = {
     id: string;
     claim: string;
     status: VerificationVerdict;
-    sources: string[];
     checkedAt: string;
-    reasoning: string;
+    reasoning: string | null;
     sources_retrieved: string[];
     sources_used: string[];
     findingId?: string;

--- a/src/shared/types/validation-finding.type.ts
+++ b/src/shared/types/validation-finding.type.ts
@@ -50,14 +50,17 @@ export type ValidationFinding = {
     /** ID de un fact verificado relacionado */
     relatedFactId?: string;
 
-    /** Estado factual del claim relacionado (true, false, possibly_true...) */
+    /** Estado factual del claim relacionado (true, false, possibly_true, unknown) */
     factStatus?: string;
 
     /** Fecha de última verificación factual */
     factCheckedAt?: string;
 
-    /** Fuentes utilizadas para determinar el estado factual */
+    /** Fuentes utilizadas por el FactChecker para emitir el veredicto */
     factSourcesUsed?: string[];
+
+    /** Razonamiento generado por el modelo para justificar el veredicto */
+    factReasoning?: string | null;
 
     /** Si el estado factual es concluyente o no */
     factIsConclusive?: boolean;

--- a/src/shared/utils/text/normalize-claim.ts
+++ b/src/shared/utils/text/normalize-claim.ts
@@ -1,0 +1,10 @@
+/**
+ * Normaliza un claim eliminando espacios innecesarios y convirtiéndolo a minúsculas.
+ * Esta función se usa para comparar claims de forma semántica simple.
+ *
+ * @param claim Texto original del claim.
+ * @returns Claim normalizado.
+ */
+export function normalizeClaim(claim: string): string {
+    return claim.trim().toLowerCase();
+}


### PR DESCRIPTION
- Enabled multi-claim detection and analysis in ValidatorAgent
- Added support for environment variable  (default 3000)
- Updated README with usage examples and best practices
- Added initial CHANGELOG.md following Keep a Changelog format